### PR TITLE
fix: (AHWR-2122) bump ws to 8.21.1 to resolve high severity advisory

### DIFF
--- a/.changeset/ahwr-2122-bump-ws.md
+++ b/.changeset/ahwr-2122-bump-ws.md
@@ -1,0 +1,5 @@
+---
+"ffc-ahwr-common-library": patch
+---
+
+Updated ws to 8.21.1 to resolve SNYK-JS-WS-17988732

--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ node_modules
 helm/**/*.lock
 *.tgz
 .vscode
+.idea

--- a/package-lock.json
+++ b/package-lock.json
@@ -14,7 +14,7 @@
         "@azure/service-bus": "7.9.5",
         "https-proxy-agent": "9.1.0",
         "joi": "18.2.1",
-        "ws": "8.21.0"
+        "ws": "8.21.1"
       },
       "bin": {
         "cdp-github-release": "ci/release-it.sh"
@@ -11612,9 +11612,9 @@
       }
     },
     "node_modules/ws": {
-      "version": "8.21.0",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-8.21.0.tgz",
-      "integrity": "sha512-Vsp28b7DRcimFQvrqu2Wek3z1iYxDCWqHYB8Qsnk/S4RfaCQzPGPyBNuVjJV3cd6UiKtUtp6sNM77gWvzcCH+g==",
+      "version": "8.21.1",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.21.1.tgz",
+      "integrity": "sha512-+0NTnW77fFN/DjQi6k/Sq/Yvk4Sgajw7urW8V+asjXnRgDs9gyGkdb7EzgfhA4goXsRIZKE28fzIXBHEzhuiWw==",
       "license": "MIT",
       "engines": {
         "node": ">=10.0.0"

--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
     "@azure/service-bus": "7.9.5",
     "https-proxy-agent": "9.1.0",
     "joi": "18.2.1",
-    "ws": "8.21.0"
+    "ws": "8.21.1"
   },
   "devDependencies": {
     "@babel/core": "7.29.7",


### PR DESCRIPTION
## Summary

Bumps the `ws` dependency from `8.21.0` to `8.21.1` to resolve a high severity advisory ([SNYK-JS-WS-17988732](https://security.snyk.io/vuln/SNYK-JS-WS-17988732)).

Because this library pins `ws` exactly and is consumed by all of the AHWR services, none of them can pick up the fix independently - it has to be released here and pulled downstream. This change was held until the version cleared the 7-day min-release-age cooldown, then the lockfile was updated.

## What Changed

- Updated `ws` to `8.21.1` in `package.json` and `package-lock.json` (lockfile churn limited to the single package)
- Added a changeset so the merge publishes a patch release (3.8.4) that the services can then consume

## Why

The advisory was failing the scheduled security scan across every service that depends on this library. `ws` is pinned to an exact version here, so the fix could not float in at the service level and had to be made centrally. The bump is a patch with no API change, so it is backward compatible for all consumers.