### PR TITLE
fix: (AHWR-2122) pin https-proxy-agent to 7.0.6 for commonjs compatibility

### DIFF
--- a/.changeset/ahwr-2122-fix-https-proxy-agent.md
+++ b/.changeset/ahwr-2122-fix-https-proxy-agent.md
@@ -1,0 +1,5 @@
+---
+"ffc-ahwr-common-library": patch
+---
+
+Pin https-proxy-agent to 7.0.6 (CommonJS) to restore Jest compatibility in consuming services

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,18 +1,18 @@
 {
   "name": "ffc-ahwr-common-library",
-  "version": "3.8.3",
+  "version": "3.8.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "ffc-ahwr-common-library",
-      "version": "3.8.3",
+      "version": "3.8.4",
       "license": "OGL-UK-3.0",
       "dependencies": {
         "@aws-sdk/client-sns": "3.1015.0",
         "@aws-sdk/client-sqs": "3.1015.0",
         "@azure/service-bus": "7.9.5",
-        "https-proxy-agent": "9.1.0",
+        "https-proxy-agent": "7.0.6",
         "joi": "18.2.1",
         "ws": "8.21.1"
       },
@@ -4252,19 +4252,6 @@
         "node": ">=20.0.0"
       }
     },
-    "node_modules/@typespec/ts-http-runtime/node_modules/https-proxy-agent": {
-      "version": "7.0.6",
-      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-7.0.6.tgz",
-      "integrity": "sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw==",
-      "license": "MIT",
-      "dependencies": {
-        "agent-base": "^7.1.2",
-        "debug": "4"
-      },
-      "engines": {
-        "node": ">= 14"
-      }
-    },
     "node_modules/@ungap/structured-clone": {
       "version": "1.3.1",
       "resolved": "https://registry.npmjs.org/@ungap/structured-clone/-/structured-clone-1.3.1.tgz",
@@ -7020,26 +7007,16 @@
       }
     },
     "node_modules/https-proxy-agent": {
-      "version": "9.1.0",
-      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-9.1.0.tgz",
-      "integrity": "sha512-ag87y7cJJ9/3+GxFr8Oy4O5faDsGRGnBGsJj/YjOSsSx/5eadKLYTMPlzuR6obgoCDDm0abAAZitXXQkMOPSpA==",
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-7.0.6.tgz",
+      "integrity": "sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw==",
       "license": "MIT",
       "dependencies": {
-        "agent-base": "9.0.0",
-        "debug": "^4.3.4",
-        "proxy-agent-negotiate": "1.1.0"
+        "agent-base": "^7.1.2",
+        "debug": "4"
       },
       "engines": {
-        "node": ">= 20"
-      }
-    },
-    "node_modules/https-proxy-agent/node_modules/agent-base": {
-      "version": "9.0.0",
-      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-9.0.0.tgz",
-      "integrity": "sha512-TQf59BsZnytt8GdJKLPfUZ54g/iaUL2OWDSFCCvMOhsHduDQxO8xC4PNeyIkVcA5KwL2phPSv0douC0fgWzmnA==",
-      "license": "MIT",
-      "engines": {
-        "node": ">= 20"
+        "node": ">= 14"
       }
     },
     "node_modules/human-id": {
@@ -9858,23 +9835,6 @@
         "loose-envify": "^1.4.0",
         "object-assign": "^4.1.1",
         "react-is": "^16.13.1"
-      }
-    },
-    "node_modules/proxy-agent-negotiate": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/proxy-agent-negotiate/-/proxy-agent-negotiate-1.1.0.tgz",
-      "integrity": "sha512-N8IBcM3UgCVzz2L2Lqv8DVntDnnC8/hiV4nEDUPkqq72TPUgYWjQc+bdZlBPZK9LzPAvOY//gAt0S0DApoOXWQ==",
-      "license": "MIT",
-      "engines": {
-        "node": ">= 20"
-      },
-      "peerDependencies": {
-        "kerberos": "^2.0.0"
-      },
-      "peerDependenciesMeta": {
-        "kerberos": {
-          "optional": true
-        }
       }
     },
     "node_modules/punycode": {

--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
     "@aws-sdk/client-sns": "3.1015.0",
     "@aws-sdk/client-sqs": "3.1015.0",
     "@azure/service-bus": "7.9.5",
-    "https-proxy-agent": "9.1.0",
+    "https-proxy-agent": "7.0.6",
     "joi": "18.2.1",
     "ws": "8.21.1"
   },


### PR DESCRIPTION
## Summary

Pins `https-proxy-agent` to `7.0.6` (CommonJS) in place of `9.1.0` (ESM-only), which was breaking Jest in every consuming service.

The `9.1.0` dependency was declared explicitly by an earlier lint-dependencies change and shipped in `3.8.4` alongside the `ws` fix. Because the library eagerly re-exports the module that imports it, any service importing the library under Jest hit an "unexpected token / cannot use import statement outside a module" error. This releases as a patch (3.8.5) and keeps the `ws` fix from 3.8.4 intact.

## What Changed

- Changed `https-proxy-agent` from `9.1.0` to `7.0.6` in `package.json` and `package-lock.json`
- Removed the ESM sub-tree it pulled in (agent-base 9.x, proxy-agent-negotiate) from the lockfile
- Added a changeset for the patch release

## Why

Version `7.0.6` is CommonJS and **is the exact version the services already resolved transitively before the dependency was declared explicitly**, so it is behaviour-neutral and Jest can load it without any transform.

The library's only usage is a simple `new HttpsProxyAgent(url)`, a named export identical across both majors, so no code change is required. Fixing it once in the library restores compatibility for all seven consuming services, rather than requiring per-service Jest configuration.